### PR TITLE
feat: add badge status variants

### DIFF
--- a/zabava_frontend/src/components/ui/badge.tsx
+++ b/zabava_frontend/src/components/ui/badge.tsx
@@ -17,6 +17,10 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        success:
+          "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/20 dark:text-emerald-100 focus-visible:ring-emerald-500/20 dark:focus-visible:ring-emerald-500/40",
+        warning:
+          "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/20 dark:text-amber-100 focus-visible:ring-amber-500/20 dark:focus-visible:ring-amber-500/40",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- add success and warning badge variants to the shared badge component for consistent status styling
- map visit and redemption states to the supported badge variants and clean up the visit memo logic
- smoke test the UI in the dev server and capture the login screen while verifying status styling

## Testing
- pnpm lint
- pnpm dev --host 0.0.0.0 --port 5173

------
https://chatgpt.com/codex/tasks/task_e_68d33f5fec6883248ed67b2fe8fb05b4