### PR TITLE
fix: sync redemption dialog balance

### DIFF
--- a/zabava_frontend/src/pages/BonusPage.tsx
+++ b/zabava_frontend/src/pages/BonusPage.tsx
@@ -1243,7 +1243,10 @@ export default function BonusPage() {
                 <div className="flex justify-between items-center mt-2">
                   <span className="text-sm">Your Balance After:</span>
                   <span className="font-bold">
-                    {userData.user.availablePoints - selectedReward.pointsCost}{" "}
+                    {Math.max(
+                      0,
+                      availablePoints - normalizePoints(selectedReward.pointsCost)
+                    )}{" "}
                     pts
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- reuse the derived available points value in the redemption dialog
- clamp the post-redemption balance after subtracting the reward cost so it never goes negative

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d344a8476883249d63f6262f062417