### PR TITLE
feat: refresh dashboards with latest submissions

### DIFF
--- a/zabava_frontend/src/hooks/usePartnerData.ts
+++ b/zabava_frontend/src/hooks/usePartnerData.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { API_BASE_URL } from "@/lib/config";
-import type { PartnerDashboardData } from "@/types/dashboard";
+import type { PartnerDashboardData, SubmissionRecord } from "@/types/dashboard";
 
 interface UsePartnerDataOptions {
   token?: string | null;
   onUnauthorized?: () => void;
+  refreshIntervalMs?: number;
+  autoRefresh?: boolean;
 }
 
 interface UsePartnerDataResult {
@@ -14,72 +16,121 @@ interface UsePartnerDataResult {
   refetch: () => Promise<void>;
 }
 
+function getTimestamp(value?: string | null): number {
+  if (!value) {
+    return 0;
+  }
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function sortPartnerSubmissions(
+  submissions: PartnerDashboardData["submissions"]
+): SubmissionRecord[] {
+  if (!Array.isArray(submissions)) {
+    return [];
+  }
+  return [...submissions].sort(
+    (a, b) => getTimestamp(b?.createdAt ?? null) - getTimestamp(a?.createdAt ?? null)
+  );
+}
+
 export function usePartnerData(
   partnerId: string | undefined,
-  { token, onUnauthorized }: UsePartnerDataOptions = {}
+  options: UsePartnerDataOptions = {}
 ): UsePartnerDataResult {
+  const {
+    token,
+    onUnauthorized,
+    refreshIntervalMs = 30000,
+    autoRefresh = true,
+  } = options;
   const [data, setData] = useState<PartnerDashboardData | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
   const abortController = useRef<AbortController | null>(null);
+  const hasLoadedRef = useRef<boolean>(false);
 
   const canFetch = useMemo(
     () => Boolean(partnerId && token),
     [partnerId, token]
   );
 
-  const fetchData = useCallback(async (): Promise<void> => {
-    if (!canFetch || !partnerId || !token) {
-      return;
+  useEffect(() => {
+    if (!canFetch) {
+      setData(null);
+      hasLoadedRef.current = false;
     }
+  }, [canFetch]);
 
-    if (abortController.current) {
-      abortController.current.abort();
-    }
+  useEffect(() => {
+    hasLoadedRef.current = false;
+  }, [partnerId]);
 
-    const controller = new AbortController();
-    abortController.current = controller;
-
-    try {
-      setLoading(true);
-      setError(null);
-
-      const response = await fetch(`${API_BASE_URL}/api/partner/${partnerId}`, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        signal: controller.signal,
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        onUnauthorized?.();
-        throw new Error("Unauthorized");
-      }
-
-      if (!response.ok) {
-        throw new Error(
-          `Request failed: ${response.status} ${response.statusText}`
-        );
-      }
-
-      const result = (await response.json()) as PartnerDashboardData;
-      setData(result);
-    } catch (unknownError) {
-      const err = unknownError as Error;
-      if (err.name === "AbortError") {
+  const fetchData = useCallback(
+    async ({ background = false }: { background?: boolean } = {}): Promise<void> => {
+      if (!canFetch || !partnerId || !token) {
         return;
       }
-      setError(err);
-      console.error("Error fetching partner data:", err);
-    } finally {
-      setLoading(false);
-    }
-  }, [canFetch, onUnauthorized, partnerId, token]);
+
+      if (abortController.current) {
+        abortController.current.abort();
+      }
+
+      const controller = new AbortController();
+      abortController.current = controller;
+
+      try {
+        if (!background) {
+          setLoading(true);
+        }
+        setError(null);
+
+        const response = await fetch(`${API_BASE_URL}/api/partner/${partnerId}`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          signal: controller.signal,
+        });
+
+        if (response.status === 401 || response.status === 403) {
+          onUnauthorized?.();
+          throw new Error("Unauthorized");
+        }
+
+        if (!response.ok) {
+          throw new Error(
+            `Request failed: ${response.status} ${response.statusText}`
+          );
+        }
+
+        const result = (await response.json()) as PartnerDashboardData;
+        const normalized: PartnerDashboardData = {
+          ...result,
+          submissions: sortPartnerSubmissions(result.submissions),
+        };
+        setData(normalized);
+        hasLoadedRef.current = true;
+      } catch (unknownError) {
+        const err = unknownError as Error;
+        if (err.name === "AbortError") {
+          return;
+        }
+        setError(err);
+        console.error("Error fetching partner data:", err);
+      } finally {
+        if (!background) {
+          setLoading(false);
+        }
+      }
+    },
+    [canFetch, onUnauthorized, partnerId, token]
+  );
 
   useEffect(() => {
     if (canFetch) {
-      void fetchData();
+      void fetchData({ background: hasLoadedRef.current });
     }
     return () => {
       if (abortController.current) {
@@ -88,9 +139,26 @@ export function usePartnerData(
     };
   }, [canFetch, fetchData]);
 
+  useEffect(() => {
+    if (!autoRefresh || !canFetch || refreshIntervalMs <= 0) {
+      return undefined;
+    }
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      void fetchData({ background: hasLoadedRef.current });
+    }, refreshIntervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [autoRefresh, canFetch, fetchData, refreshIntervalMs]);
+
   const refetch = useCallback(async (): Promise<void> => {
     if (canFetch) {
-      await fetchData();
+      await fetchData({ background: hasLoadedRef.current });
     }
   }, [canFetch, fetchData]);
 

--- a/zabava_frontend/src/pages/PartnerDashboard.tsx
+++ b/zabava_frontend/src/pages/PartnerDashboard.tsx
@@ -106,6 +106,7 @@ export default function PartnerDashboard() {
   const { data, loading, error, refetch } = usePartnerData(partnerId, {
     token,
     onUnauthorized: logout,
+    refreshIntervalMs: 15000,
   });
   const [refreshing, setRefreshing] = useState<boolean>(false);
   const [activeSection, setActiveSection] = useState<


### PR DESCRIPTION
## Summary
- add background polling and consistent sorting to partner data fetching so submissions refresh automatically and newest entries render first
- ensure admin analytics endpoints and dashboard views consistently sort submissions by newest created date for listings and exports
- plumb faster refresh interval on the partner dashboard while keeping manual refresh functionality intact

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3525e3f188324b5a56d8b7a71f0a2